### PR TITLE
Switch JSON library from json-lib to gson

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,12 @@
 # ccl-testing Change Log
 
+## TBD
+* j4ccl-ssh **4.5**
+
+### Corrections
+* Fix [#44](https://github.com/cerner/ccl-testing/issues/44) loss of precision when deserializing F8 values on reply message.
+
+
 ## 2020-01-17
 * ccl-maven-plugin **3.3**
 * cerreal-maven-plugin **2.2**

--- a/CONTRIBUTORS.md
+++ b/CONTRIBUTORS.md
@@ -1,8 +1,10 @@
 * Cerner Corporation
 * Fred Ecketson [@feckerston][fred-eckertson]
 * Bill Pennington [@bill.pennington][bill-pennington]
-* Nick Feldmann [@runningguy84] [nicholas-feldmann]
+* Nick Feldmann [@runningguy84][nicholas-feldmann]
+* Joshua Kuestersteffen [@jkuester][joshua-kuestersteffen]
 
 [fred-eckertson]: https://github.com/feckertson
 [bill-pennington]: https://github.com/bill.pennington
-[nicholas-feldmann] https://github.com/runningguy84
+[nicholas-feldmann]: https://github.com/runningguy84
+[joshua-kuestersteffen]: https://github.com/jkuester

--- a/ccl-maven-plugin/src/main/resources/META-INF/licenses/LICENSES
+++ b/ccl-maven-plugin/src/main/resources/META-INF/licenses/LICENSES
@@ -12,12 +12,12 @@ http://www.apache.org/licenses/LICENSE-2.0.html
 * ehcache-core
 * ezmorph
 * ftp-util
+* gson
 * j4ccl
 * j4ccl-ssh
 * jdom
 * joda-time
 * jsch-util
-* json-lib
 * maven-artifact
 * maven-model
 * maven-plugin-api

--- a/j4ccl-ssh/pom.xml
+++ b/j4ccl-ssh/pom.xml
@@ -210,6 +210,10 @@
             <artifactId>jsch</artifactId>
         </dependency>
         <dependency>
+            <groupId>com.google.code.gson</groupId>
+            <artifactId>gson</artifactId>
+        </dependency>
+        <dependency>
             <groupId>com.google.code.jetm</groupId>
             <artifactId>jetm-reporting-utilities</artifactId>
         </dependency>
@@ -233,13 +237,6 @@
             <groupId>joda-time</groupId>
             <artifactId>joda-time</artifactId>
         </dependency>
-        <dependency>
-            <groupId>net.sf.json-lib</groupId>
-            <artifactId>json-lib</artifactId>
-            <version>2.4</version>
-            <classifier>jdk15</classifier>
-        </dependency>
-
         <dependency>
             <groupId>junit</groupId>
             <artifactId>junit</artifactId>

--- a/j4ccl-ssh/src/main/java/com/cerner/ccl/j4ccl/impl/util/RecordWriter.java
+++ b/j4ccl-ssh/src/main/java/com/cerner/ccl/j4ccl/impl/util/RecordWriter.java
@@ -9,10 +9,10 @@ import com.cerner.ccl.j4ccl.record.DynamicRecordList;
 import com.cerner.ccl.j4ccl.record.Field;
 import com.cerner.ccl.j4ccl.record.Record;
 import com.cerner.ccl.j4ccl.record.RecordList;
-
-import net.sf.json.JSON;
-import net.sf.json.JSONArray;
-import net.sf.json.JSONObject;
+import com.google.gson.Gson;
+import com.google.gson.JsonArray;
+import com.google.gson.JsonElement;
+import com.google.gson.JsonObject;
 
 /**
  * A utility to put values from an external source into a {@link Record} object.
@@ -23,9 +23,11 @@ import net.sf.json.JSONObject;
 
 public class RecordWriter {
     private static final Pattern jsonDatePattern;
+    private static final Gson gson;
 
     static {
         jsonDatePattern = Pattern.compile("^\\/Date\\(.*\\)\\/$");
+        gson = new Gson();
     }
 
     /**
@@ -39,27 +41,28 @@ public class RecordWriter {
      *             If the given record structure is not in the given JSON text.
      */
     public static void putFromJson(final String json, final Record record) {
-        final JSONObject jsonObject = JSONObject.fromObject(json);
+        final JsonObject jsonObject = gson.fromJson(json, JsonObject.class);
         // JSON data from CCL is presumed to be all upper-case
         final String recordNameUpper = record.getName().toUpperCase(Locale.getDefault());
         if (!jsonObject.has(recordNameUpper))
             throw new IllegalArgumentException("JSON does not contain record " + recordNameUpper);
 
-        putFromJsonObject(jsonObject.getJSONObject(recordNameUpper), record);
+        putFromJsonObject(jsonObject.getAsJsonObject(recordNameUpper), record);
     }
 
     /**
      * Populate a record structure from the contents of a JSON data object.
      *
      * @param json
-     *            The {@link JSONObject} from which data will be pulled.
+     *            The {@link JsonElement} from which data will be pulled.
      * @param record
      *            A {@link Record} object into which the values in the JSON object will be populated.
      * @throws IllegalArgumentException
-     *             If the data type of a field within the given record identifies itself as a complext type but is not a
+     *             If the data type of a field within the given record identifies itself as a complex type but is not a
      *             known complex type.
      */
-    private static void putFromJsonObject(final JSONObject json, final Record record) {
+    private static void putFromJsonObject(final JsonElement json, final Record record) {
+        final JsonObject jsonObject = json.getAsJsonObject();
         for (final Field field : record.getStructure().getFields()) {
             final String fieldName = field.getName().toUpperCase(Locale.getDefault());
             final DataType dataType = field.getType();
@@ -67,19 +70,19 @@ public class RecordWriter {
             if (dataType.isComplexType()) {
                 switch (dataType) {
                 case LIST:
-                    putFixedListFromJson((JSON) json.get(fieldName), field, record.getList(fieldName));
+                    putFixedListFromJson(jsonObject.get(fieldName), field, record.getList(fieldName));
                     break;
                 case DYNAMIC_LIST:
-                    putVariableListFromJson(json.getJSONArray(fieldName), record.getDynamicList(fieldName));
+                    putVariableListFromJson(jsonObject.getAsJsonArray(fieldName), record.getDynamicList(fieldName));
                     break;
                 case RECORD:
-                    putFromJsonObject(json.getJSONObject(fieldName), record.getRecord(fieldName));
+                    putFromJsonObject(jsonObject.get(fieldName), record.getRecord(fieldName));
                     break;
                 default:
                     throw new IllegalArgumentException("Unrecognized complex data type: " + dataType);
                 }
             } else
-                putPrimitiveFromJson(json, field, record);
+                putPrimitiveFromJson(jsonObject, field, record);
         }
     }
 
@@ -87,18 +90,19 @@ public class RecordWriter {
      * Populate a fixed-length list from JSON data objects.
      *
      * @param sourceJson
-     *            A {@link JSON} object representing an array of JSON data objects or a single JSON data object from
-     *            which data will be pulled.
+     *            A {@link JsonElement} object representing an array of JSON data objects or a single JSON data object
+     *            from which data will be pulled.
      * @param field
      *            A {@link Field} object representing the fixed-length list to be populated.
      * @param recordList
      *            A {@link RecordList} containing records into which values will be populated.
      */
-    private static void putFixedListFromJson(final JSON sourceJson, final Field field, final RecordList recordList) {
-        if (sourceJson.isArray())
-            putFixedListDeepFromJson((JSONArray) sourceJson, field, recordList);
+    private static void putFixedListFromJson(final JsonElement sourceJson, final Field field,
+            final RecordList recordList) {
+        if (sourceJson.isJsonArray())
+            putFixedListDeepFromJson(sourceJson.getAsJsonArray(), field, recordList);
         else
-            putFixedListShallowFromJson((JSONObject) sourceJson, field, recordList);
+            putFixedListShallowFromJson(sourceJson.getAsJsonObject(), field, recordList);
     }
 
     /**
@@ -112,7 +116,7 @@ public class RecordWriter {
      * @throws ArrayIndexOutOfBoundsException
      *             If the size of the data object array and the size of the record list do not match.
      */
-    private static void putFixedListDeepFromJson(final JSONArray array, final Field field,
+    private static void putFixedListDeepFromJson(final JsonArray array, final Field field,
             final RecordList recordList) {
         if (array.size() != recordList.getSize())
             throw new ArrayIndexOutOfBoundsException(
@@ -121,14 +125,14 @@ public class RecordWriter {
 
         int arrayIndex = 0;
         for (final Record record : recordList)
-            putFromJsonObject(array.getJSONObject(arrayIndex++), record);
+            putFromJsonObject(array.get(arrayIndex++), record);
     }
 
     /**
      * Populate a single-element list with data from a JSON data object.
      *
      * @param json
-     *            A {@link JSON} data object containing the values to be stored in the record list.
+     *            A {@link JsonObject} data object containing the values to be stored in the record list.
      * @param field
      *            A {@link Field} object representing the fixed-length list to be populated.
      * @param recordList
@@ -136,7 +140,7 @@ public class RecordWriter {
      * @throws ArrayIndexOutOfBoundsException
      *             If the size of the given record list is not 1.
      */
-    private static void putFixedListShallowFromJson(final JSONObject json, final Field field,
+    private static void putFixedListShallowFromJson(final JsonObject json, final Field field,
             final RecordList recordList) {
         if (recordList.getSize() != 1)
             throw new ArrayIndexOutOfBoundsException(
@@ -150,7 +154,7 @@ public class RecordWriter {
      * Store a primitive value into a record structure.
      *
      * @param json
-     *            A {@link JSONObject} object representing the JSON data to be stored.
+     *            A {@link JsonObject} object representing the JSON data to be stored.
      * @param field
      *            A {@link Field} object representing the field into which data is to be stored.
      * @param record
@@ -160,27 +164,28 @@ public class RecordWriter {
      * @throws RuntimeException
      *             If the field represents a date and that date value does not match the expected pattern.
      */
-    private static void putPrimitiveFromJson(final JSONObject json, final Field field, final Record record) {
+    private static void putPrimitiveFromJson(final JsonObject json, final Field field, final Record record) {
         final String fieldName = field.getName().toUpperCase(Locale.getDefault());
         if (!json.has(fieldName))
             throw new NoSuchFieldError("Expected primitive " + field.getName() + ", but did not exist in JSON object.");
 
+        final JsonElement jsonElement = json.get(fieldName);
         final DataType dataType = field.getType();
         switch (dataType) {
         case VC:
-            record.setVC(fieldName, json.getString(fieldName));
+            record.setVC(fieldName, jsonElement.getAsString());
             break;
         case F8:
-            record.setF8(fieldName, json.getDouble(fieldName));
+            record.setF8(fieldName, jsonElement.getAsDouble());
             break;
         case I4:
-            record.setI4(fieldName, json.getInt(fieldName));
+            record.setI4(fieldName, jsonElement.getAsInt());
             break;
         case I2:
-            record.setI2(fieldName, (short) json.getInt(fieldName));
+            record.setI2(fieldName, jsonElement.getAsShort());
             break;
         case DQ8:
-            String dateStringValue = json.getString(fieldName);
+            String dateStringValue = jsonElement.getAsString();
             if (!jsonDatePattern.matcher(dateStringValue).matches())
                 throw new RuntimeException(
                         "Date value " + dateStringValue + " does not match pattern " + jsonDatePattern.toString());
@@ -192,7 +197,7 @@ public class RecordWriter {
                 record.setDQ8(fieldName, CclUtils.convertTimestamp(dateStringValue));
             return;
         case CHARACTER:
-            record.setChar(fieldName, json.getString(fieldName));
+            record.setChar(fieldName, jsonElement.getAsString());
             break;
         default:
             throw new IllegalArgumentException("Unrecognized primitive type: " + dataType);
@@ -203,17 +208,17 @@ public class RecordWriter {
      * Populate a variable-length list with data from a list of JSON data objects.
      *
      * @param array
-     *            A {@link JSONArray} object from which JSON data objects with values will be pulled.
+     *            A {@link JsonArray} object from which JSON data objects with values will be pulled.
      * @param recordList
      *            A {@link DynamicRecordList} object containing records into which values from the JSON data objects
      *            will be populated.
      * @throws IllegalArgumentException
      *             If the size of the given array does not match the size of the record list.
      */
-    private static void putVariableListFromJson(final JSONArray array, final DynamicRecordList recordList) {
+    private static void putVariableListFromJson(final JsonArray array, final DynamicRecordList recordList) {
         int listIndex = 0;
-        for (final Iterator<?> it = array.iterator(); it.hasNext();) {
-            final JSONObject object = (JSONObject) it.next();
+        for (final Iterator<JsonElement> it = array.iterator(); it.hasNext();) {
+            final JsonElement object = it.next();
             /*
              * Add a record if the size of the array exceeds the size of the list; otherwise, use an existing record
              */

--- a/j4ccl-ssh/src/main/resources/META-INF/licenses/LICENSES
+++ b/j4ccl-ssh/src/main/resources/META-INF/licenses/LICENSES
@@ -12,10 +12,10 @@ http://www.apache.org/licenses/LICENSE-2.0.html
 * ehcache-core
 * ezmorph
 * ftp-util
+* gson
 * j4ccl
 * joda-time
 * jsch-util
-* json-lib
 
 BSD License
 http://www.opensource.org/licenses/bsd-license.php

--- a/j4ccl-ssh/src/test/java/com/cerner/ccl/j4ccl/impl/util/RecordWriterTest.java
+++ b/j4ccl-ssh/src/test/java/com/cerner/ccl/j4ccl/impl/util/RecordWriterTest.java
@@ -254,10 +254,10 @@ public class RecordWriterTest {
      */
     @Test
     public void testPutFromJsonF8() {
-        final String json = "{\"REPLY\":{\"" + F8_FIELD.getName() + "\":2.025000}}";
+        final String json = "{\"REPLY\":{\"" + F8_FIELD.getName() + "\":6546546542.025000}}";
         final Record record = mockRecord("REPLY", mockStructure(F8_FIELD));
         RecordWriter.putFromJson(json, record);
-        verify(record, times(1)).setF8(F8_FIELD.getName(), 2.025);
+        verify(record, times(1)).setF8(F8_FIELD.getName(), 6546546542.025);
     }
 
     /**

--- a/parent-pom/pom.xml
+++ b/parent-pom/pom.xml
@@ -712,6 +712,11 @@
                 <scope>test</scope>
             </dependency>
             <dependency>
+                <groupId>com.google.code.gson</groupId>
+                <artifactId>gson</artifactId>
+                <version>2.8.6</version>
+            </dependency>
+            <dependency>
                 <groupId>com.google.code.jetm</groupId>
                 <artifactId>jetm-reporting-utilities</artifactId>
                 <version>1.0.1</version>
@@ -730,11 +735,6 @@
                 <groupId>net.sf.ehcache</groupId>
                 <artifactId>ehcache-core</artifactId>
                 <version>2.6.11</version>
-            </dependency>
-            <dependency>
-                <groupId>net.sf.json-lib</groupId>
-                <artifactId>json-lib</artifactId>
-                <version>2.4</version>
             </dependency>
             <dependency>
                 <groupId>org.slf4j</groupId>

--- a/whitenoise/whitenoise-maven-plugin/src/main/resources/META-INF/licenses/LICENSES
+++ b/whitenoise/whitenoise-maven-plugin/src/main/resources/META-INF/licenses/LICENSES
@@ -12,12 +12,12 @@ http://www.apache.org/licenses/LICENSE-2.0.html
 * ehcache-core
 * ezmorph
 * ftp-util
+* gson
 * j4ccl
 * j4ccl-ssh
 * jdom
 * joda-time
 * jsch-util
-* json-lib
 * maven-artifact
 * maven-model
 * maven-plugin-api

--- a/whitenoise/whitenoise-parent-pom/pom.xml
+++ b/whitenoise/whitenoise-parent-pom/pom.xml
@@ -728,6 +728,11 @@
                 <scope>test</scope>
             </dependency>
             <dependency>
+                <groupId>com.google.code.gson</groupId>
+                <artifactId>gson</artifactId>
+                <version>2.8.6</version>
+            </dependency>
+            <dependency>
                 <groupId>com.google.code.jetm</groupId>
                 <artifactId>jetm-reporting-utilities</artifactId>
                 <version>1.0.1</version>
@@ -746,11 +751,6 @@
                 <groupId>net.sf.ehcache</groupId>
                 <artifactId>ehcache-core</artifactId>
                 <version>2.6.11</version>
-            </dependency>
-            <dependency>
-                <groupId>net.sf.json-lib</groupId>
-                <artifactId>json-lib</artifactId>
-                <version>2.4</version>
             </dependency>
             <dependency>
                 <groupId>org.slf4j</groupId>


### PR DESCRIPTION
The json-lib dependency is no longer being maintained ([has not been updated since 2010](https://sourceforge.net/projects/json-lib/files/)) and it depends on an old (unmaintained) version of the Apache commons-lang dependency with a [defect in the NumberUtils](https://github.com/apache/commons-lang/pull/156) that can cause a loss of precision when unpacking numeric values from a String.

These changes are to switch the library used for packing/unpacking the JSON request/reply data from json-lib to Google's popular [gson](https://github.com/google/gson) library. 

Closes #44 